### PR TITLE
Data loader quality cuts

### DIFF
--- a/cosmos20_colors/data_loader.py
+++ b/cosmos20_colors/data_loader.py
@@ -43,11 +43,18 @@ def load_cosmos20(drn=None, bn=COSMOS20_BASENAME, apply_cuts=True):
     cat = Table.read(fn, format="fits", hdu=1)
 
     if apply_cuts:
+        cat_out = Table()
         cuts = []
         sel_galaxies = np.array(cat["lp_type"] == 0).astype(bool)
         cuts.append(sel_galaxies)
 
         msk = np.prod(cuts, axis=0).astype(bool)
-        cat = cat[msk]
+        for key in cat.keys():
+            cat_out[key] = np.array(cat[key][msk])
+
+        return cat_out
+
+    else:
+        return cat
 
     return cat

--- a/cosmos20_colors/data_loader.py
+++ b/cosmos20_colors/data_loader.py
@@ -5,6 +5,7 @@ from astropy.table import Table
 
 COSMOS20_BASENAME = "COSMOS2020_Farmer_processed_hlin.fits"
 
+SKY_AREA = 1.21  # square degrees
 
 NANFILL = -999.0
 

--- a/cosmos20_colors/tests/test_data_loader.py
+++ b/cosmos20_colors/tests/test_data_loader.py
@@ -3,7 +3,7 @@
 import pytest
 import os
 import subprocess
-from ..data_loader import load_cosmos20, COSMOS20_BASENAME
+from ..data_loader import load_cosmos20, COSMOS20_BASENAME, SKY_AREA
 
 
 _THIS_DRNAME = os.path.dirname(os.path.abspath(__file__))
@@ -53,3 +53,20 @@ def test_cosmos20_dataset_loads():
     """Enforce that dataset loads when it exists"""
     cat = load_cosmos20()
     assert cat is not None
+
+
+@pytest.mark.skipif(not HAS_COSMOS20, reason=HAS_COSMOS20_MSG)
+def test_cosmos20_quality_cuts_do_not_change():
+    """Enforce that the data-loader quality cuts are frozen.
+    The purpose of this unit test is to standardize the quality cuts made on the
+    catalog that define the summary statistics. If the quality cuts change,
+    this unit test will need to be updated.
+    """
+    cat = load_cosmos20(apply_cuts=True)
+    assert len(cat) == 706601
+
+
+@pytest.mark.skipif(not HAS_COSMOS20, reason=HAS_COSMOS20_MSG)
+def test_cosmos20_sky_area_is_frozen():
+    """Enforce that the sky area of COSMOS-20 is frozen."""
+    assert SKY_AREA == 1.21


### PR DESCRIPTION
This PR brings in some additional cuts to the COSMOS20 dataset used to measure our summary statistics. In particular, the `load_cosmos20` has new behavior associated with the `apply_cuts` argument, such that galaxies with wildly unphysical values of absolute magnitude in any band are excluded from the dataset. This histogram gives an example. The galaxies with Mi~1000 are now excluded by the new version of the `apply_cuts` argument brought in with this PR.

![cosmos20_mag_cuts](https://user-images.githubusercontent.com/6951595/197574550-7bf56244-dea1-423d-8e83-fe0527ab4774.png)

There is an additional unit test that freezes the behavior of the `load_cosmos20` function. This way, any changes to the cuts must be done alongside a conscious change to the new unit test. 